### PR TITLE
Handle force refresh for workout schedule

### DIFF
--- a/src/components/WorkoutSchedule/WorkoutDetailView.jsx
+++ b/src/components/WorkoutSchedule/WorkoutDetailView.jsx
@@ -565,6 +565,7 @@ export default function WorkoutDetailView({ onWorkoutComplete } = {}) {
     }
   }, [locationStateKey]);
   const dayQueryValue = searchParams.get("day");
+  const forceRefreshQuery = searchParams.get("forceRefresh");
   const stateDayNumber = useMemo(() => {
     const originalDayNumber =
       parsedLocationState?.originalApiData?.day_number ??
@@ -578,6 +579,12 @@ export default function WorkoutDetailView({ onWorkoutComplete } = {}) {
     if (!Number.isNaN(fromQuery)) return fromQuery;
     return stateDayNumber;
   }, [dayQueryValue, stateDayNumber]);
+  const forceRefreshRequested = useMemo(() => {
+    if (parsedLocationState?.forceRefresh) return true;
+    if (!forceRefreshQuery) return false;
+    const normalized = String(forceRefreshQuery).toLowerCase();
+    return normalized === "1" || normalized === "true" || normalized === "yes";
+  }, [forceRefreshQuery, parsedLocationState]);
 
   // state
   const [exercises, setExercises] = useState([]);
@@ -1229,11 +1236,11 @@ export default function WorkoutDetailView({ onWorkoutComplete } = {}) {
 
   /* ---------- load day data from router state ---------- */
   useEffect(() => {
-    const cleanup = loadLatestSchedule();
+    const cleanup = loadLatestSchedule(forceRefreshRequested);
     return () => {
       if (typeof cleanup === "function") cleanup();
     };
-  }, [loadLatestSchedule]);
+  }, [forceRefreshRequested, loadLatestSchedule]);
 
   useEffect(() => {
     isMountedRef.current = true;


### PR DESCRIPTION
## Summary
- read a forceRefresh flag from navigation state or query parameters
- call loadLatestSchedule with the requested force reload on mount
- keep loading state cleared when refresh is skipped

## Testing
- npm test -- --runInBand *(fails: node: bad option: --runInBand)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fc4988da08327bd818c4096ac01ca)