### PR TITLE
Ensure workout detail refresh fetches v2 schedule

### DIFF
--- a/src/components/WorkoutSchedule/WorkoutDetailView.jsx
+++ b/src/components/WorkoutSchedule/WorkoutDetailView.jsx
@@ -1108,9 +1108,6 @@ export default function WorkoutDetailView({ onWorkoutComplete } = {}) {
 
       if (!appliedFromState) {
         resetLocalState();
-      } else if (!force) {
-        setLoading(false);
-        return () => {};
       }
 
       const fetchSignature = JSON.stringify({


### PR DESCRIPTION
## Summary
- ensure workout detail view fetches the latest v2 schedule even when router state data exists, so refreshed pages reflect current sets

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fc662f9c08327bf7f5eb4fd80079e)